### PR TITLE
Lagt til dokumentasjon

### DIFF
--- a/src/søknad/genererSøknadHtml.tsx
+++ b/src/søknad/genererSøknadHtml.tsx
@@ -44,7 +44,7 @@ const mapFelter = (felt: HtmlFelt, nivå: number = 1) => {
                             return mapFelter(verdi, Math.min(nivå, 4));
                         } else {
                             return (
-                                <div className={nivåClassName} key={index}>
+                                <div className={`${nivåClassName}`} key={index}>
                                     {mapFelter(verdi, Math.min(nivå + 1, 4))}
                                 </div>
                             );

--- a/src/søknad/genererSøknadHtml.tsx
+++ b/src/søknad/genererSøknadHtml.tsx
@@ -39,11 +39,17 @@ const mapFelter = (felt: HtmlFelt, nivå: number = 1) => {
             return (
                 <div>
                     {header(felt, nivå, nivåClassName)}
-                    {felt.verdier.map((verdi, index) => (
-                        <div className={nivåClassName} key={index}>
-                            {mapFelter(verdi, Math.min(nivå + 1, 4))}
-                        </div>
-                    ))}
+                    {felt.verdier.map((verdi, index) => {
+                        if (verdi.type == 'AVSNITT' && verdi.beholdMargin) {
+                            return mapFelter(verdi, Math.min(nivå, 4));
+                        } else {
+                            return (
+                                <div className={nivåClassName} key={index}>
+                                    {mapFelter(verdi, Math.min(nivå + 1, 4))}
+                                </div>
+                            );
+                        }
+                    })}
                 </div>
             );
         case 'LINJE':

--- a/src/søknad/genererSøknadHtml.tsx
+++ b/src/søknad/genererSøknadHtml.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import soknadCss from './soknadCss';
-import { Avsnitt, HtmlFelt, Søknad, Verdi } from './typer';
+import { Avsnitt, Dokumentasjon, HtmlFelt, Søknad, Verdi } from './typer';
 import { formaterNorskDato } from '../felles/datoFormat';
 import { HtmlLang } from '../felles/HtmlLang';
 import { NavSvg } from '../felles/nav_svg';
@@ -59,6 +59,25 @@ const mapFelter = (felt: HtmlFelt, nivå: number = 1) => {
     }
 };
 
+const mapDokumentasjon = (dokumentasjon: Dokumentasjon[]) => {
+    return (
+        <div className={'level-2'}>
+            {dokumentasjon.map((d) => (
+                <>
+                    <h2>{d.label}</h2>
+                    {d.dokument.map((d) => (
+                        <div className={'level-3'}>
+                            <h3>{d.label}</h3>
+                            <div>{d.labelSendtInnTidligere}</div>
+                            <div>{d.labelAntall}</div>
+                        </div>
+                    ))}
+                </>
+            ))}
+        </div>
+    );
+};
+
 const genererSøknadHtml = async (data: Søknad): Promise<string> => {
     const asyncHtml = () => (
         <html lang={HtmlLang.NB}>
@@ -77,6 +96,7 @@ const genererSøknadHtml = async (data: Søknad): Promise<string> => {
                         <h1>{tittelSøknad(data.type)}</h1>
                     </div>
                     {mapFelter(data.avsnitt)}
+                    {mapDokumentasjon(data.dokumentasjon)}
                 </div>
             </body>
         </html>

--- a/src/søknad/soknadCss.ts
+++ b/src/søknad/soknadCss.ts
@@ -66,15 +66,18 @@ h4 {
 }
 
 .level-2 {
-    margin-left: 10px
+    margin-left: 10px;
+    page-break-inside: avoid;
 }
 
 .level-3 {
-    margin-left: 20px
+    margin-left: 20px;
+    page-break-inside: avoid;
 }
 
 .level-4 {
-    margin-left: 30px
+    margin-left: 30px;
+    page-break-inside: avoid;
 }
 
 .alternativer {

--- a/src/søknad/soknadCss.ts
+++ b/src/søknad/soknadCss.ts
@@ -66,15 +66,15 @@ h4 {
 }
 
 .level-2 {
-    margin-left: 20px
+    margin-left: 10px
 }
 
 .level-3 {
-    margin-left: 40px
+    margin-left: 20px
 }
 
 .level-4 {
-    margin-left: 50px
+    margin-left: 30px
 }
 
 .alternativer {

--- a/src/søknad/typer.ts
+++ b/src/søknad/typer.ts
@@ -4,6 +4,7 @@ export interface Søknad {
     type: Stønadstype;
     mottattTidspunkt: string;
     avsnitt: Avsnitt;
+    dokumentasjon: Dokumentasjon[];
 }
 
 export interface Avsnitt {
@@ -24,3 +25,12 @@ export interface Linje {
 }
 
 export type HtmlFelt = Avsnitt | Verdi | Linje;
+
+export interface Dokumentasjon {
+    label: string;
+    dokument: {
+        label: string;
+        labelSendtInnTidligere: string;
+        labelAntall: string;
+    }[];
+}

--- a/src/søknad/typer.ts
+++ b/src/søknad/typer.ts
@@ -10,6 +10,7 @@ export interface Avsnitt {
     type: 'AVSNITT';
     label: string;
     verdier: HtmlFelt[];
+    beholdMargin?: boolean;
 }
 
 export interface Verdi {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
* Skal vise at vedlegget er koblet til et barn
* Skal vise informasjon om man har sendt inn tidligere

* Halvert margin då det tidligere var relativt mye margin
* Lagt til at man prøver å ikke ta page break på tekst som hører sammen

* https://github.com/navikt/tilleggsstonader-soknad/pull/230
* https://github.com/navikt/tilleggsstonader-kontrakter/pull/55

Jeg tenker dette er greit til videre, det er mulig det kommer noen ønsker senere om hvordan dette faktiskt burde se ut.. 

<img width="371" alt="image" src="https://github.com/navikt/tilleggsstonader-htmlify/assets/937168/8945f292-1b38-4e77-a35b-68f3ba129227">


https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-18307


## Sånn her ser det ut i EF:
<img width="501" alt="image" src="https://github.com/navikt/tilleggsstonader-htmlify/assets/937168/e2c9fa51-2bda-4da4-a20f-0cafdad7b48b">
