### PR TITLE
Mottar alternativer som en enkel string med prefix for å kunne ha pre…

### DIFF
--- a/src/søknad/genererSøknadHtml.tsx
+++ b/src/søknad/genererSøknadHtml.tsx
@@ -1,17 +1,11 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import soknadCss from './soknadCss';
-import { Avsnitt, Dokumentasjon, HtmlFelt, Søknad, Verdi } from './typer';
+import { Avsnitt, Dokumentasjon, HtmlFelt, Søknad } from './typer';
 import { formaterNorskDato } from '../felles/datoFormat';
 import { HtmlLang } from '../felles/HtmlLang';
 import { NavSvg } from '../felles/nav_svg';
 import { tittelSøknad } from '../felles/stønadstype';
-
-const alternativer = (verdi: Verdi) => {
-    return (
-        verdi.alternativer && <div className={'alternativer'}>{verdi.alternativer.join(', ')}</div>
-    );
-};
 
 const header = (avsnitt: Avsnitt, nivå: number, className: string) => {
     switch (nivå) {
@@ -31,7 +25,7 @@ const mapFelter = (felt: HtmlFelt, nivå: number = 1) => {
         case 'VERDI':
             return (
                 <>
-                    {alternativer(felt)}
+                    {felt.alternativer && <div className={'alternativer'}>{felt.alternativer}</div>}
                     {felt.verdi}
                 </>
             );

--- a/src/søknad/typer.ts
+++ b/src/søknad/typer.ts
@@ -17,7 +17,7 @@ export interface Avsnitt {
 export interface Verdi {
     type: 'VERDI';
     verdi: string;
-    alternativer?: string[];
+    alternativer?: string;
 }
 
 export interface Linje {


### PR DESCRIPTION
…fix i visningen

### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å vise 
`Alternativer: Alt1, Alt2` i stedet for kun `Alt1, Alt2`

<img width="294" alt="image" src="https://github.com/navikt/tilleggsstonader-htmlify/assets/937168/7fa74143-6fba-4b63-8e27-b5f1ab5a845f">

