### PR TITLE
:bug: Legg til IKKE_AKTUELT som resultat og oppdater navn for å matche backend

### DIFF
--- a/src/internt-vedtak/VilkårperioderContent.tsx
+++ b/src/internt-vedtak/VilkårperioderContent.tsx
@@ -4,7 +4,7 @@ import { Begrunnelse, KommentarSlettet, NonBreakingDiv } from './felles';
 import {
     kildeVilkårperiodeTilTekst,
     ResultatVilkårperiode,
-    resultatVurderingVilkårperiodeTilTekst,
+    resultatDelvilkårperiodeTilTekst,
     svarVurderingTilTekst,
     typeStønadsperiodeTilTekst,
     Vilkårperiode,
@@ -42,7 +42,7 @@ const Vurdering: React.FC<{ navn: string; vurdering?: VurderingVilkårperiode }>
         <NonBreakingDiv>
             <div>
                 <strong>{navn}</strong> (
-                {tekstEllerFeil(resultatVurderingVilkårperiodeTilTekst, vurdering.resultat)})
+                {tekstEllerFeil(resultatDelvilkårperiodeTilTekst, vurdering.resultat)})
             </div>
             <div>Svar: {tekstEllerFeil(svarVurderingTilTekst, vurdering.svar)}</div>
         </NonBreakingDiv>

--- a/src/internt-vedtak/typer/vilkårperiode.ts
+++ b/src/internt-vedtak/typer/vilkårperiode.ts
@@ -18,7 +18,7 @@ export interface DelvilkårVilkårperiode {
 
 export interface VurderingVilkårperiode {
     svar?: SvarVurdering;
-    resultat: ResultatVurderingVilkårperiode;
+    resultat: ResultatDelvilkårperiode;
 }
 
 export interface Stønadsperiode extends Periode {
@@ -55,21 +55,18 @@ export const svarVurderingTilTekst: Record<SvarVurdering, string> = {
     NEI: 'Nei',
 };
 
-enum ResultatVurderingVilkårperiode {
+enum ResultatDelvilkårperiode {
     OPPFYLT = 'OPPFYLT',
     IKKE_OPPFYLT = 'IKKE_OPPFYLT',
     IKKE_VURDERT = 'IKKE_VURDERT',
-    SLETTET = 'SLETTET',
+    IKKE_AKTUELT = 'IKKE_AKTUELT',
 }
 
-export const resultatVurderingVilkårperiodeTilTekst: Record<
-    ResultatVurderingVilkårperiode,
-    string
-> = {
+export const resultatDelvilkårperiodeTilTekst: Record<ResultatDelvilkårperiode, string> = {
     OPPFYLT: 'Oppfylt',
     IKKE_OPPFYLT: 'Ikke oppfylt',
     IKKE_VURDERT: 'Ikke vurdert',
-    SLETTET: 'Slettet',
+    IKKE_AKTUELT: 'Ikke aktuelt',
 };
 
 enum TypeStønadsperiode {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lag internt vedtak feiler fordi `IKKE_AKTUELT` ikke finnes i enum. Oppdaterte også navnet på enumet så det er likt som det er i sak-backend