### PR TITLE
Debian 11 (som er default) inneholder tilsynelatende en kritisk sårbar versjon av openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs:18
+FROM gcr.io/distroless/nodejs18-debian12
 
 ADD ./build /app
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For å fikse sårbarheter i openssl

# Før
![image](https://github.com/user-attachments/assets/421fd210-15b0-4ae2-b044-6155ab2f1df3)

# Etter
![image](https://github.com/user-attachments/assets/b2684337-5a2a-47cd-9eb8-0ab8d75f480a)

