### PR TITLE
Legg til støtte for ingen utdanning som svar på læremidelvilkår

### DIFF
--- a/src/internt-vedtak/typer/vilkårperiode.ts
+++ b/src/internt-vedtak/typer/vilkårperiode.ts
@@ -94,6 +94,7 @@ enum TypeStønadsperiode {
     UTDANNING = 'UTDANNING',
     REELL_ARBEIDSSØKER = 'REELL_ARBEIDSSØKER',
     INGEN_AKTIVITET = 'INGEN_AKTIVITET',
+    INGEN_UTDANNING = 'INGEN_UTDANNING',
 }
 
 export const typeStønadsperiodeTilTekst: Record<TypeStønadsperiode, string> = {
@@ -110,4 +111,5 @@ export const typeStønadsperiodeTilTekst: Record<TypeStønadsperiode, string> = 
     UTDANNING: 'Utdanning',
     REELL_ARBEIDSSØKER: 'Reell arbeidssøker',
     INGEN_AKTIVITET: 'Ingen aktivitet',
+    INGEN_UTDANNING: 'Ingen utdanning',
 };


### PR DESCRIPTION
Valgte å utvide eksisterende enum med ny aktivitet siden det var enklere for meg å lage en ny flyt enn å finne ta høyde for alle effekter ved å redigere en eksisterende flyt. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23719

![Screenshot 2024-12-17 at 15 55 49](https://github.com/user-attachments/assets/0e200785-8109-4cbd-8fbd-43900a5ebde2)

### Hvorfor er denne endringen nødvendig? ✨
