### PR TITLE
👔 Ikke vis stønadsperioder når bruker vedtaksperioder

### DIFF
--- a/src/internt-vedtak/StønadsperioderContent.tsx
+++ b/src/internt-vedtak/StønadsperioderContent.tsx
@@ -17,28 +17,30 @@ const StønadsperiodeRad: React.FC<{ periode: Stønadsperiode }> = ({ periode })
 };
 
 const StønadsperioderContent: React.FC<{
-    perioder: Stønadsperiode[];
+    perioder?: Stønadsperiode[];
 }> = ({ perioder }) => {
-    return (
-        <NonBreakingDiv className={'stonadsperioder'}>
-            <h2>Overlappsperioder</h2>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Målgruppe</th>
-                        <th>Aktivitet</th>
-                        <th>Fra</th>
-                        <th>Til</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {perioder.map((periode, index) => (
-                        <StønadsperiodeRad key={index} periode={periode} />
-                    ))}
-                </tbody>
-            </table>
-        </NonBreakingDiv>
-    );
+    if (perioder) {
+        return (
+            <NonBreakingDiv className={'stonadsperioder'}>
+                <h2>Overlappsperioder</h2>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Målgruppe</th>
+                            <th>Aktivitet</th>
+                            <th>Fra</th>
+                            <th>Til</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {perioder.map((periode, index) => (
+                            <StønadsperiodeRad key={index} periode={periode} />
+                        ))}
+                    </tbody>
+                </table>
+            </NonBreakingDiv>
+        );
+    }
 };
 
 export default StønadsperioderContent;

--- a/src/internt-vedtak/typer/interntVedtak.ts
+++ b/src/internt-vedtak/typer/interntVedtak.ts
@@ -11,7 +11,7 @@ export interface InterntVedtak {
     søknad?: Søknad;
     målgrupper: Vilkårperiode[];
     aktiviteter: Vilkårperiode[];
-    stønadsperioder: Stønadsperiode[];
+    stønadsperioder?: Stønadsperiode[];
     vedtaksperioder: Vedtaksperiode[];
     vilkår: Vilkår[];
     beregningsresultat?: Beregningsresultat;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker ikke å vise informasjon om stønadsperioder i internt vedtak dersom saksbehandler bruker vedtaksperioder. Dersom stønadsperioder er en liste (enten tom eller ikke) skal stønadsperioder vises i internt vedtak. Dersom stønadsperioder er null så skal ikke stønadsperioder vises i internt vedtak.