### PR TITLE
Rammevedtak privat bil delperiode

### DIFF
--- a/src/internt-vedtak/RammevedtakContent.tsx
+++ b/src/internt-vedtak/RammevedtakContent.tsx
@@ -10,6 +10,10 @@ export const RammevedtakContent: React.FC<{ rammevedtak: RammevedtakPrivatBil | 
         return null;
     }
 
+    if (rammevedtak.reiser.length === 0) {
+        return null;
+    }
+
     return (
         <>
             <h2>Rammevedtak kjøring med privat bil</h2>
@@ -39,35 +43,37 @@ export const RammevedtakContent: React.FC<{ rammevedtak: RammevedtakPrivatBil | 
                             </tr>
                         </thead>
                         <tbody>
-                            <tr key={reise.reiseId}>
-                                <td>{reise.grunnlag.reisedagerPerUke}</td>
-                                <td>
-                                    {reise.grunnlag.reiseavstandEnVei}
-                                    {' km'}
-                                </td>
-                                <td>
-                                    {
-                                        reise.grunnlag.satser[reise.grunnlag.satser.length - 1]
-                                            .kilometersats
-                                    }
-                                    {' kr'}
-                                </td>
-                                <td>
-                                    {reise.grunnlag.ekstrakostnader.bompengerPerDag}
-                                    {' kr'}
-                                </td>
-                                <td>
-                                    {reise.grunnlag.ekstrakostnader.fergekostnadPerDag}
-                                    {' kr'}
-                                </td>
-                                <td>
-                                    {
-                                        reise.grunnlag.satser[reise.grunnlag.satser.length - 1]
-                                            .dagsatsUtenParkering
-                                    }
-                                    {' kr'}
-                                </td>
-                            </tr>
+                            {reise.grunnlag.delperioder.map((delperiode) => (
+                                <tr key={reise.reiseId}>
+                                    <td>{delperiode.reisedagerPerUke}</td>
+                                    <td>
+                                        {reise.grunnlag.reiseavstandEnVei}
+                                        {' km'}
+                                    </td>
+                                    <td>
+                                        {
+                                            delperiode.satser[delperiode.satser.length - 1]
+                                                .kilometersats
+                                        }
+                                        {' kr'}
+                                    </td>
+                                    <td>
+                                        {delperiode.ekstrakostnader.bompengerPerDag}
+                                        {' kr'}
+                                    </td>
+                                    <td>
+                                        {delperiode.ekstrakostnader.fergekostnadPerDag}
+                                        {' kr'}
+                                    </td>
+                                    <td>
+                                        {
+                                            delperiode.satser[delperiode.satser.length - 1]
+                                                .dagsatsUtenParkering
+                                        }
+                                        {' kr'}
+                                    </td>
+                                </tr>
+                            ))}
                         </tbody>
                     </table>
                 </div>

--- a/src/internt-vedtak/typer/rammevedtakPrivatBil.ts
+++ b/src/internt-vedtak/typer/rammevedtakPrivatBil.ts
@@ -13,11 +13,17 @@ export interface RammeForReiseMedPrivatBil {
 export interface BeregningsgrunnlagForReiseMedPrivatBil {
     fom: string;
     tom: string;
-    reisedagerPerUke: number;
+    delperioder: Delperiode[];
     reiseavstandEnVei: number;
-    ekstrakostnader: Ekstrakostnader;
-    satser: SatsForPeriodePrivatBil[];
     vedtaksperioder: Vedtaksperiode[];
+}
+
+export interface Delperiode {
+    fom: string;
+    tom: string;
+    satser: SatsForPeriodePrivatBil[];
+    reisedagerPerUke: number;
+    ekstrakostnader: Ekstrakostnader;
 }
 
 export interface Ekstrakostnader {

--- a/src/internt-vedtak/typer/rammevedtakPrivatBil.ts
+++ b/src/internt-vedtak/typer/rammevedtakPrivatBil.ts
@@ -28,12 +28,12 @@ export interface Delperiode {
 
 export interface Ekstrakostnader {
     bompengerPerDag?: number;
-    fergekostnadPerDag: number;
+    fergekostnadPerDag?: number;
 }
 export interface SatsForPeriodePrivatBil {
     fom: string;
     tom: string;
-    satsBekreftetVedVedtakstidspunkt: boolean;
     kilometersats: number;
     dagsatsUtenParkering: number;
+    satsBekreftetVedVedtakstidspunkt: boolean;
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

viser frem delperioder i rammevedtaket
<img width="641" height="350" alt="Screenshot 2026-04-09 at 21 24 54" src="https://github.com/user-attachments/assets/0bbaee92-3099-4aaf-82ab-96267225756c" />


NOTE: Må kanskje vise delperioder i bergeningsresultatet også?