### PR TITLE
Legger til reisedagerLabel på uke for kjøreliste

### DIFF
--- a/src/kjøreliste/genererKjørelisteHtml.tsx
+++ b/src/kjøreliste/genererKjørelisteHtml.tsx
@@ -26,6 +26,7 @@ const mapKjørelisteUker = (uker: Uke[]) => {
     return uker.map((uke) => (
         <div className={'uke'}>
             <h2>{uke.ukeLabel}</h2>
+            <div className={'label'}>{uke.reisedagerLabel}</div>
             <div className={'label'}>{uke.spørsmål}</div>
             {uke.dager.map((dag) => mapDag(dag))}
         </div>

--- a/src/kjøreliste/typer.ts
+++ b/src/kjøreliste/typer.ts
@@ -11,6 +11,7 @@ export interface Kjøreliste {
 
 export interface Uke {
     ukeLabel: string;
+    reisedagerLabel: string;
     spørsmål: string;
     dager: Dag[];
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Legger til tekst om ukentlige reisedager, som skal vises i tilleggsstonader-soknad når vi støtter delperioder

<img width="716" height="668" alt="Skjermbilde 2026-04-10 kl  15 30 55" src="https://github.com/user-attachments/assets/3b276dfc-8ac8-462c-b5bc-9e2fcbf9aa68" />
