### PR TITLE
🐛 Legg til fallback hvis ukjent aktivitetsadresse.

### DIFF
--- a/src/kjøreliste-behandling-brev/OppsummertBeregningsresultat.tsx
+++ b/src/kjøreliste-behandling-brev/OppsummertBeregningsresultat.tsx
@@ -12,7 +12,8 @@ export const OppsummertBeregningsresultat: React.FC<{
                 return (
                     <div key={reiseIndex} style={{ marginBottom: '2rem' }}>
                         <h3>
-                            Reise til {reise.aktivitetsadresse} ({reise.reiseavstandEnVei} km)
+                            Reise til {reise.aktivitetsadresse ?? 'ukjent adresse'} (
+                            {reise.reiseavstandEnVei} km)
                         </h3>
                         <BeregningsresultatTabell oppsummertReise={reise} />
                     </div>


### PR DESCRIPTION
På sikt burde denne endres til å ikke være nullable fra sak. Det er saker i prod hvor denne er `null` (for offentlig transport) så det krever en omskrivning for å få til.

❗ Tar gjerne tilbakemlding på om det burde stå noe annet som gjør det tydligere for SB at vi ikke kjenner til adressen.