### PR TITLE
Fiks skrivefeil i dataklasse som gjør at signatur ikke tas i mot

### DIFF
--- a/src/kjøreliste-behandling-brev/genererKjørelisteBehandlingBrev.tsx
+++ b/src/kjøreliste-behandling-brev/genererKjørelisteBehandlingBrev.tsx
@@ -30,7 +30,7 @@ export const genererKjørelisteBehandlingBrev = (data: KjørelisteBehandlingBrev
                 <Avslutning />
                 <Signatur
                     enhet={data.behandlendeEnhet}
-                    saksbehandlersignatur={data.saksbehandlersignatur}
+                    saksbehandlersignatur={data.saksbehandlerSignatur}
                 />
             </body>
         </html>

--- a/src/kjøreliste-behandling-brev/typer.ts
+++ b/src/kjøreliste-behandling-brev/typer.ts
@@ -3,7 +3,7 @@ export interface KjørelisteBehandlingBrevData {
     ident: string;
     behandletDato: string;
     behandlendeEnhet: string;
-    saksbehandlersignatur?: string;
+    saksbehandlerSignatur?: string;
     beregning: PrivatBilOppsummertBeregning;
 }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ulik skrivemåte i backend og htmlify så saksbehandlersignatur tas ikke i mot