### PR TITLE
💄 Rydd opp i utseende på tabell

### DIFF
--- a/src/kjøreliste-behandling-brev/BeregningsresultatTabell.tsx
+++ b/src/kjøreliste-behandling-brev/BeregningsresultatTabell.tsx
@@ -5,32 +5,59 @@ import { kronerMedTusenSkilleEllerStrek } from '../felles/tekstutils';
 export const BeregningsresultatTabell: React.FC<{
     oppsummertReise: OppsummertBeregningForReise;
 }> = ({ oppsummertReise }) => {
+    const harBompengeutgifter = oppsummertReise.perioder.some(
+        (periode) => periode.bompengerTotalt && periode.bompengerTotalt > 0
+    );
+
+    const harFergekostnader = oppsummertReise.perioder.some(
+        (periode) => periode.fergekostnadTotalt && periode.fergekostnadTotalt > 0
+    );
+
     return (
-        <table style={{ fontSize: '90%', width: '100%' }}>
-            <thead>
-                <tr>
-                    <th>Uke</th>
-                    <th>Periode</th>
-                    <th>Antall dager som dekkes</th>
-                    <th>Totale bompengekostnader</th>
-                    <th>Totale fergekostnader</th>
-                    <th>Totale parkeringsutgifter</th>
-                    <th>Stønadsbeløp</th>
-                </tr>
-            </thead>
-            <tbody>
-                {oppsummertReise.perioder.map((periode, index) => (
-                    <tr key={`${periode.fom}-${periode.tom}-${index}`}>
-                        <td>Uke {periode.ukenummer}</td>
-                        <td>{formaterPeriode(periode)}</td>
-                        <td>{periode.antallGodkjenteReisedager}</td>
-                        <td>{kronerMedTusenSkilleEllerStrek(periode.bompengerTotalt)}</td>
-                        <td>{kronerMedTusenSkilleEllerStrek(periode.fergekostnadTotalt)}</td>
-                        <td>{kronerMedTusenSkilleEllerStrek(periode.parkeringskostnadTotalt)}</td>
-                        <td>{kronerMedTusenSkilleEllerStrek(periode.stønadsbeløp)}</td>
+        <div>
+            <table style={{ fontSize: '89%' }}>
+                <thead>
+                    <tr>
+                        <th>Uke</th>
+                        <th>Periode</th>
+                        <th>Antall dager</th>
+                        {harBompengeutgifter && <th>Bompenger</th>}
+                        {harFergekostnader && <th>Fergekostnad</th>}
+                        <th>Parkeringskostnad</th>
+                        <th>Stønadsbeløp</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {oppsummertReise.perioder.map((periode, index) => (
+                        <tr key={`${periode.fom}-${periode.tom}-${index}`}>
+                            <td>{periode.ukenummer}</td>
+                            <td style={{ minWidth: '140px' }}>{formaterPeriode(periode)}</td>
+                            <td>{periode.antallGodkjenteReisedager}</td>
+                            {harBompengeutgifter && (
+                                <td className="høyrejustert">
+                                    {kronerMedTusenSkilleEllerStrek(periode.bompengerTotalt)}
+                                </td>
+                            )}
+                            {harFergekostnader && (
+                                <td className="høyrejustert">
+                                    {kronerMedTusenSkilleEllerStrek(periode.fergekostnadTotalt)}
+                                </td>
+                            )}
+                            <td className="høyrejustert">
+                                {kronerMedTusenSkilleEllerStrek(periode.parkeringskostnadTotalt)}
+                            </td>
+                            <td className="høyrejustert">
+                                {kronerMedTusenSkilleEllerStrek(periode.stønadsbeløp)}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            <p className="tabell-beskrivelse">
+                Antall dager viser hvor mange dager innenfor perioden hvor kjøring med privat bil
+                dekkes. Parkeringskostnad, fergekostnad og bompenger er oppgitt som totalsum for
+                hele uken.
+            </p>
+        </div>
     );
 };

--- a/src/kjøreliste-behandling-brev/BeregningsresultatTabell.tsx
+++ b/src/kjøreliste-behandling-brev/BeregningsresultatTabell.tsx
@@ -30,9 +30,9 @@ export const BeregningsresultatTabell: React.FC<{
                 <tbody>
                     {oppsummertReise.perioder.map((periode, index) => (
                         <tr key={`${periode.fom}-${periode.tom}-${index}`}>
-                            <td>{periode.ukenummer}</td>
+                            <td className="høyrejustert">{periode.ukenummer}</td>
                             <td style={{ minWidth: '140px' }}>{formaterPeriode(periode)}</td>
-                            <td>{periode.antallGodkjenteReisedager}</td>
+                            <td className="høyrejustert">{periode.antallGodkjenteReisedager}</td>
                             {harBompengeutgifter && (
                                 <td className="høyrejustert">
                                     {kronerMedTusenSkilleEllerStrek(periode.bompengerTotalt)}
@@ -54,9 +54,8 @@ export const BeregningsresultatTabell: React.FC<{
                 </tbody>
             </table>
             <p className="tabell-beskrivelse">
-                Antall dager viser hvor mange dager innenfor perioden hvor kjøring med privat bil
-                dekkes. Parkeringskostnad, fergekostnad og bompenger er oppgitt som totalsum for
-                hele uken.
+                Antall dager viser hvor mange dager innenfor perioden hvor kjøring med bil dekkes.
+                Parkeringskostnad, fergekostnad og bompenger dekkes med en samlet sum per uke.
             </p>
         </div>
     );

--- a/src/kjøreliste-behandling-brev/kjorelisteBehandlingBrevCss.ts
+++ b/src/kjøreliste-behandling-brev/kjorelisteBehandlingBrevCss.ts
@@ -63,6 +63,22 @@ td, th {
     padding: 3px 10px;
 }
 
+th {
+    vertical-align: top;
+    overflow-wrap: break-word;
+    hyphens: auto;
+}
+
+.tabell-beskrivelse {
+    font-size: 80%;
+    margin-bottom: 4px;
+    line-height: 140%;
+}
+
+.høyrejustert {
+    text-align: right;
+}
+
 .avsnitt {
     margin-bottom: 2rem;
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Endret på overskrifter og gitt fast bredde så periode ikke skal knekke
- Fjerner bom og ferge dersom brukeren ikke har det
- Lagt på en liten forklaring under om de nye overskriftene for å si at de gjelder for en hel uke

✅ hos de funksjonelle

Tabeller med og uten ferge/bom:
<img width="827" height="762" alt="image" src="https://github.com/user-attachments/assets/c72090d2-24ff-42e2-a908-de3e552fad8c" />
