### PR TITLE
✨ Manuell begrunnelse i kjørelistebrev

### DIFF
--- a/src/kjøreliste-behandling-brev/genererKjørelisteBehandlingBrev.tsx
+++ b/src/kjøreliste-behandling-brev/genererKjørelisteBehandlingBrev.tsx
@@ -62,6 +62,12 @@ const Innhold: React.FC<{ data: KjørelisteBehandlingBrevData }> = ({ data }) =>
                 kvittering før beløpet blir utbetalt. Du får pengene inn på konto i løpet av 2-3
                 virkedager.
             </p>
+            {data.begrunnelse && (
+                <div>
+                    <h3>Begrunnelse for vedtaket:</h3>
+                    <p>{data.begrunnelse}</p>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/kjøreliste-behandling-brev/typer.ts
+++ b/src/kjøreliste-behandling-brev/typer.ts
@@ -6,6 +6,7 @@ export interface KjørelisteBehandlingBrevData {
     saksbehandlerSignatur?: string;
     beregning: PrivatBilOppsummertBeregning;
     satser: SatsDagligReisePrivatBil[];
+    begrunnelse?: string;
 }
 
 export interface PrivatBilOppsummertBeregning {


### PR DESCRIPTION
## Manuell begrunnelse i kjørelistebrev

Legger til støtte for å vise en manuell begrunnelse i kjørelistebrevet.

### Endringer
- `KjørelisteBehandlingBrevRequest` tar nå inn et valgfritt `begrunnelse`-felt
- Begrunnelsen vises nederst i brevet under overskriften "Begrunnelse for vedtaket:" (kun når definert)
 
Relaterte PRer:
- tilleggsstonader-sak: https://github.com/navikt/tilleggsstonader-sak/pull/1191
- tilleggsstonader-sak-frontend: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/1151

<img width="1415" height="692" alt="image" src="https://github.com/user-attachments/assets/83b9d43f-8fa4-4b0d-ae88-3b2343b4d451" />


/cc @AStrand94 @sarahjelle @Filipcl